### PR TITLE
fix: nested hydration overlap

### DIFF
--- a/packages/example-common/src/components/ExampleClientComponentNesting/index.tsx
+++ b/packages/example-common/src/components/ExampleClientComponentNesting/index.tsx
@@ -1,4 +1,4 @@
-import { lazy } from "react";
+import { lazy, useCallback, useState } from "react";
 import { useRecoilState } from "recoil";
 import { textState } from "../../state/textState";
 
@@ -42,11 +42,21 @@ ExampleClientComponent2.reactiveHydrateLoader = true;
 export const ExampleClientComponentNesting = () => {
   const [text] = useRecoilState(textState);
 
+  const [count, setCount] = useState(0);
+
+  const handleClick = useCallback(() => setCount((c) => c + 1), []);
+
   return (
     <>
       <h4>ExampleClientComponentNesting</h4>
 
       <div>recoil textState = {text}</div>
+
+      <div>useState count = {count}</div>
+
+      <button onClick={handleClick} data-click>
+        count++
+      </button>
 
       <button data-click>hydrate</button>
 

--- a/packages/reactive-hydration/src/ReactiveHydrateLoader/index.tsx
+++ b/packages/reactive-hydration/src/ReactiveHydrateLoader/index.tsx
@@ -1,52 +1,73 @@
-import { useEffect, useMemo, useRef } from "react-actual";
+import { memo, useEffect, useMemo, useRef } from "react-actual";
 import { useContext, useState } from "../react-actual";
 import { ReactiveHydrateContext } from "../ReactiveHydrateContext";
+import { componentElementRegistry } from "../componentElementRegistry";
 
 interface ReactiveHydrateLoaderProps {
   name: string;
   index: number;
 }
 
-export const ReactiveHydrateLoader = (props: ReactiveHydrateLoaderProps) => {
-  const { name } = props;
+export const ReactiveHydrateLoader = memo(
+  (props: ReactiveHydrateLoaderProps) => {
+    const { name } = props;
 
-  const {
-    reactiveHydrateNestedHtmlByComponentPath,
-    parentComponentPath,
-    registerComponentPath,
-    unregisterComponentPath,
-  } = useContext(ReactiveHydrateContext);
+    const {
+      reactiveHydrateNestedHtmlByComponentPath,
+      parentComponentPath,
+      registerComponentPath,
+      unregisterComponentPath,
+    } = useContext(ReactiveHydrateContext);
 
-  const [componentIndex, setComponentIndex] = useState(0);
+    const [componentIndex, setComponentIndex] = useState(0);
 
-  /**
-   * Disable the React 18 double effect call in dev, otherwise we bump indexes too many times.
-   */
-  const effectCalled = useRef(false);
+    /**
+     * Disable the React 18 double effect call in dev, otherwise we bump indexes too many times.
+     */
+    const effectCalled = useRef(false);
 
-  useEffect(() => {
-    if (effectCalled.current) return;
+    useEffect(() => {
+      if (effectCalled.current) return;
 
-    effectCalled.current = true;
+      effectCalled.current = true;
 
-    setComponentIndex(registerComponentPath?.(name) ?? 0);
+      setComponentIndex(registerComponentPath?.(name) ?? 0);
 
-    return () => unregisterComponentPath?.(name);
-  }, [registerComponentPath, unregisterComponentPath, name]);
+      return () => unregisterComponentPath?.(name);
+    }, [registerComponentPath, unregisterComponentPath, name]);
 
-  const componentPathComputed = useMemo(
-    () => [...parentComponentPath, name, componentIndex],
-    [name, parentComponentPath, componentIndex]
-  );
+    const componentPathComputed = useMemo(
+      () => [...parentComponentPath, name, componentIndex],
+      [name, parentComponentPath, componentIndex]
+    );
 
-  const componentPathKey = componentPathComputed.join(".");
+    const componentPathKey = componentPathComputed.join(".");
 
-  const reactiveHydrateNestedHtml =
-    reactiveHydrateNestedHtmlByComponentPath?.[componentPathKey];
+    const reactiveHydrateNestedHtml =
+      reactiveHydrateNestedHtmlByComponentPath?.[componentPathKey];
 
-  return (
-    <div
-      dangerouslySetInnerHTML={{ __html: reactiveHydrateNestedHtml ?? "" }}
-    />
-  );
-};
+    const ref = (el: HTMLDivElement | null | undefined) => {
+      const existingEl = componentElementRegistry.get(componentPathKey);
+
+      console.log(
+        "*** componentElementRegistry[componentPathKey]",
+        existingEl,
+        componentPathKey,
+        componentElementRegistry,
+        // @ts-expect-error
+        componentElementRegistry.id
+      );
+
+      if (!existingEl) return;
+
+      el?.replaceWith(existingEl);
+    };
+
+    return (
+      <div
+        ref={ref}
+        dangerouslySetInnerHTML={{ __html: reactiveHydrateNestedHtml ?? "" }}
+      />
+    );
+  }
+);

--- a/packages/reactive-hydration/src/ReactiveHydrationContainer/ReactiveHydrationContainerInner.tsx
+++ b/packages/reactive-hydration/src/ReactiveHydrationContainer/ReactiveHydrationContainerInner.tsx
@@ -22,6 +22,7 @@ import { usePluginRecoil } from "./plugins/recoil";
 import { Hydrate, Hydrator } from "./types";
 import { pluginContext } from "./plugins/context";
 import { ReactiveHydrationInnardsContext } from "../ReactiveHydrationInnardsContext";
+import { componentElementRegistry } from "../componentElementRegistry";
 
 const hydratedComponentIdsMap = new Map<string, boolean>();
 
@@ -414,6 +415,8 @@ export const ReactiveHydrationContainerInner = memo(
           />,
           $newElement
         );
+
+        componentElementRegistry.set(componentPath, $newElement);
 
         const key = [...contextPortalTreePath, `${name}[${id}]`].join(" > ");
 

--- a/packages/reactive-hydration/src/componentElementRegistry/index.ts
+++ b/packages/reactive-hydration/src/componentElementRegistry/index.ts
@@ -1,0 +1,13 @@
+export const componentElementRegistry = new Map<string, HTMLElement>();
+
+if (typeof global !== "undefined") {
+  // @ts-expect-error
+  if (global.componentElementRegistry) {
+    module.exports =
+      // @ts-expect-error
+      global.componentElementRegistry;
+  } else {
+    // @ts-expect-error
+    global.componentElementRegistry = exports;
+  }
+}


### PR DESCRIPTION
fixing nested hydration where when initially hydrating a child, but then hydrating its parent over it, the child becomes unclickable due to being replaced by the `ReactiveHydrateLoader` placeholder hydration suppression `<div>`.